### PR TITLE
Fix possible bad boot filename:

### DIFF
--- a/option.go
+++ b/option.go
@@ -164,8 +164,7 @@ func (s *Server) setNetworkBootOpts(ctx context.Context, m *dhcpv4.DHCPv4, n *da
 func (s *Server) bootfileAndNextServer(ctx context.Context, uClass UserClass, opt60, bin string, tftp netaddr.IPPort, ipxe, iscript *url.URL) (string, net.IP) {
 	var nextServer net.IP
 	var bootfile string
-	if s.OTELEnabled {
-		tp := otelhelpers.TraceparentStringFromContext(ctx)
+	if tp := otelhelpers.TraceparentStringFromContext(ctx); s.OTELEnabled && tp != "" {
 		bin = fmt.Sprintf("%s-%v", bin, tp)
 	}
 	// If a machine is in an ipxe boot loop, it is likely to be that we aren't matching on IPXE or Tinkerbell userclass (option 77).


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
If no opentelemetry traceparent is found in the context while setting the bootfileAndNextServer but otel is enabled we were sending a bootfile name like: `unidonly-`. This fixes this.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
