### PR TITLE
Add setting DHCP option 7:

### DIFF
--- a/handler/reservation/option.go
+++ b/handler/reservation/option.go
@@ -104,6 +104,9 @@ func (h *Handler) setDHCPOpts(_ context.Context, _ *dhcpv4.DHCPv4, d *data.DHCP)
 	if d.DefaultGateway.Compare(netip.Addr{}) != 0 {
 		mods = append(mods, dhcpv4.WithRouter(d.DefaultGateway.AsSlice()))
 	}
+	if h.SyslogAddr.Compare(netip.Addr{}) != 0 {
+		mods = append(mods, dhcpv4.WithOption(dhcpv4.OptGeneric(dhcpv4.OptionLogServer, h.SyslogAddr.AsSlice())))
+	}
 
 	return mods
 }

--- a/handler/reservation/option_test.go
+++ b/handler/reservation/option_test.go
@@ -33,7 +33,7 @@ func TestSetDHCPOpts(t *testing.T) {
 		want   *dhcpv4.DHCPv4
 	}{
 		"success": {
-			server: Handler{Log: logr.Discard()},
+			server: Handler{Log: logr.Discard(), SyslogAddr: netip.MustParseAddr("192.168.7.7")},
 			args: args{
 				in0: context.Background(),
 				m:   &dhcpv4.DHCPv4{Options: dhcpv4.OptionsFromList(dhcpv4.OptParameterRequestList(dhcpv4.OptionSubnetMask))},
@@ -68,6 +68,7 @@ func TestSetDHCPOpts(t *testing.T) {
 				ServerIPAddr:  []byte{0, 0, 0, 0},
 				GatewayIPAddr: []byte{0, 0, 0, 0},
 				Options: dhcpv4.OptionsFromList(
+					dhcpv4.OptGeneric(dhcpv4.OptionLogServer, []byte{192, 168, 7, 7}),
 					dhcpv4.OptSubnetMask(net.IPMask{255, 255, 255, 0}),
 					dhcpv4.OptBroadcastAddress(net.IP{192, 168, 4, 255}),
 					dhcpv4.OptIPAddressLeaseTime(time.Duration(84600)*time.Second),
@@ -100,8 +101,9 @@ func TestSetDHCPOpts(t *testing.T) {
 					Enabled:           tt.server.Netboot.Enabled,
 					UserClass:         tt.server.Netboot.UserClass,
 				},
-				IPAddr:  tt.server.IPAddr,
-				Backend: tt.server.Backend,
+				IPAddr:     tt.server.IPAddr,
+				Backend:    tt.server.Backend,
+				SyslogAddr: tt.server.SyslogAddr,
 			}
 			mods := s.setDHCPOpts(tt.args.in0, tt.args.m, tt.args.d)
 			finalPkt, err := dhcpv4.New(mods...)

--- a/handler/reservation/reservation.go
+++ b/handler/reservation/reservation.go
@@ -31,6 +31,9 @@ type Handler struct {
 	// For example, the filename will be "snp.efi-00-23b1e307bb35484f535a1f772c06910e-d887dc3912240434-01".
 	// <original filename>-00-<trace id>-<span id>-<trace flags>
 	OTELEnabled bool
+
+	// SyslogAddr is the address to send syslog messages to. DHCP Option 7.
+	SyslogAddr netip.Addr
 }
 
 // Netboot holds the netboot configuration details used in running a DHCP server.


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allow dhcp clients that set a log server to have a destination to send to.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #19 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
