### PR TITLE
Run code coverage like other Tinkerbell projects

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,5 +23,5 @@ jobs:
       run: make test
     - name: generate coverage report
       run: make cover
-    - name: Codecov
-      uses: codecov/codecov-action@v3.1.4
+    - name: Upload coverage report (codcov.io)
+      run: bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
I'm seeing weirdness with the current codecov. Non Go files are affecting the coverage reported by codecov. Using the bash script upload instead of the GitHub action.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
