### PR TITLE
Only parse gateway if not an empty string:

### DIFF
--- a/backend/kube/kube.go
+++ b/backend/kube/kube.go
@@ -213,8 +213,10 @@ func toDHCPData(h *v1alpha1.DHCP) (*data.DHCP, error) {
 	}
 
 	// Gateway is optional, but should be a valid IP address if present
-	if d.DefaultGateway, err = netip.ParseAddr(h.IP.Gateway); err != nil {
-		return nil, err
+	if h.IP.Gateway != "" {
+		if d.DefaultGateway, err = netip.ParseAddr(h.IP.Gateway); err != nil {
+			return nil, err
+		}
 	}
 
 	// name servers, optional


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
An empty string will cause an error to be returned. As this field is optional, that is not the expected behavior.

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
