### PR TITLE
Allow for customization of iPXE script URL:

### DIFF
--- a/example/fileBackend/main.go
+++ b/example/fileBackend/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/equinix-labs/otel-init-go/otelinit"
 	"github.com/go-logr/logr"
 	"github.com/go-logr/stdr"
+	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/server4"
 	"github.com/tinkerbell/dhcp"
 	"github.com/tinkerbell/dhcp/backend/file"
@@ -43,8 +44,10 @@ func main() {
 		Netboot: reservation.Netboot{
 			IPXEBinServerTFTP: netip.MustParseAddrPort("192.168.1.34:69"),
 			IPXEBinServerHTTP: &url.URL{Scheme: "http", Host: "192.168.1.34:8080"},
-			IPXEScriptURL:     &url.URL{Scheme: "https", Host: "boot.netboot.xyz"},
-			Enabled:           true,
+			IPXEScriptURL: func(*dhcpv4.DHCPv4) *url.URL {
+				return &url.URL{Scheme: "https", Host: "boot.netboot.xyz"}
+			},
+			Enabled: true,
 		},
 		OTELEnabled: true,
 		Backend:     backend,

--- a/example/kubeBackend/main.go
+++ b/example/kubeBackend/main.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/equinix-labs/otel-init-go/otelinit"
 	"github.com/go-logr/stdr"
+	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/insomniacslk/dhcp/dhcpv4/server4"
 	"github.com/tinkerbell/dhcp"
 	"github.com/tinkerbell/dhcp/backend/kube"
@@ -44,8 +45,10 @@ func main() {
 		Netboot: reservation.Netboot{
 			IPXEBinServerTFTP: netip.MustParseAddrPort("192.168.2.50:69"),
 			IPXEBinServerHTTP: &url.URL{Scheme: "http", Host: "192.168.2.50:8080"},
-			IPXEScriptURL:     &url.URL{Scheme: "http", Host: "192.168.2.50", Path: "auto.ipxe"},
-			Enabled:           true,
+			IPXEScriptURL: func(*dhcpv4.DHCPv4) *url.URL {
+				return &url.URL{Scheme: "http", Host: "192.168.2.50", Path: "auto.ipxe"}
+			},
+			Enabled: true,
 		},
 		OTELEnabled: true,
 		Backend:     backend,

--- a/handler/reservation/option.go
+++ b/handler/reservation/option.go
@@ -144,7 +144,10 @@ func (h *Handler) setNetworkBootOpts(ctx context.Context, m *dhcpv4.DHCPv4, n *d
 				return
 			}
 			uClass := UserClass(string(m.GetOneOption(dhcpv4.OptionUserClassInformation)))
-			ipxeScript := h.Netboot.IPXEScriptURL
+			var ipxeScript *url.URL
+			if h.Netboot.IPXEScriptURL != nil {
+				ipxeScript = h.Netboot.IPXEScriptURL(m)
+			}
 			if n.IPXEScriptURL != nil {
 				ipxeScript = n.IPXEScriptURL
 			}

--- a/handler/reservation/option_test.go
+++ b/handler/reservation/option_test.go
@@ -271,7 +271,9 @@ func TestSetNetworkBootOpts(t *testing.T) {
 			want: &dhcpv4.DHCPv4{ServerIPAddr: net.IPv4(0, 0, 0, 0), BootFileName: "/netboot-not-allowed"},
 		},
 		"netboot allowed": {
-			server: &Handler{Log: logr.Discard(), Netboot: Netboot{IPXEScriptURL: &url.URL{Scheme: "http", Host: "localhost:8181", Path: "/01:02:03:04:05:06/auto.ipxe"}}},
+			server: &Handler{Log: logr.Discard(), Netboot: Netboot{IPXEScriptURL: func(*dhcpv4.DHCPv4) *url.URL {
+				return &url.URL{Scheme: "http", Host: "localhost:8181", Path: "/01:02:03:04:05:06/auto.ipxe"}
+			}}},
 			args: args{
 				in0: context.Background(),
 				m: &dhcpv4.DHCPv4{
@@ -293,7 +295,9 @@ func TestSetNetworkBootOpts(t *testing.T) {
 			)},
 		},
 		"netboot not allowed, arch unknown": {
-			server: &Handler{Log: logr.Discard(), Netboot: Netboot{IPXEScriptURL: &url.URL{Scheme: "http", Host: "localhost:8181", Path: "/01:02:03:04:05:06/auto.ipxe"}}},
+			server: &Handler{Log: logr.Discard(), Netboot: Netboot{IPXEScriptURL: func(*dhcpv4.DHCPv4) *url.URL {
+				return &url.URL{Scheme: "http", Host: "localhost:8181", Path: "/01:02:03:04:05:06/auto.ipxe"}
+			}}},
 			args: args{
 				in0: context.Background(),
 				m: &dhcpv4.DHCPv4{

--- a/handler/reservation/reservation.go
+++ b/handler/reservation/reservation.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 
 	"github.com/go-logr/logr"
+	"github.com/insomniacslk/dhcp/dhcpv4"
 	"github.com/tinkerbell/dhcp/handler"
 )
 
@@ -45,7 +46,7 @@ type Netboot struct {
 	IPXEBinServerHTTP *url.URL
 
 	// IPXEScriptURL is the URL to the IPXE script to use.
-	IPXEScriptURL *url.URL
+	IPXEScriptURL func(*dhcpv4.DHCPv4) *url.URL
 
 	// Enabled is whether to enable sending netboot DHCP options.
 	Enabled bool


### PR DESCRIPTION
## Description

<!--- Please describe what this PR is going to change -->
This allows consumers the ability to customize the iPXE script URL based on information in the DHCP packet. This flexibility will allow users to do things like host the iPXE script at dynamic URL path endpoints. for example /<mac address>/script.ipxe

## Why is this needed

<!--- Link to issue you have raised -->

Fixes: #

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->


## How are existing users impacted? What migration steps/scripts do we need?

<!--- Fixes a bug, unblocks installation, removes a component of the stack etc -->
<!--- Requires a DB migration script, etc. -->


## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
